### PR TITLE
Added some error handlers and robustness checks for setup script Fixes #32

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
       doc/conf.py |
       )$
 
-- repo: https://gitlab.com/PyCQA/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: 4.0.1
   hooks:
   - id: flake8

--- a/env/setup-conda-env.sh
+++ b/env/setup-conda-env.sh
@@ -5,14 +5,14 @@ function check_python {
     python_version_l=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
     python_lib=$(python --version | tr '[:upper:]' '[:lower:]' | sed 's/ //g' | sed 's/\.[^.]*$//')
     min_required_version=3.5
-    if [ $(echo $python_version'>'$min_required_version | bc -l) == 1 ]; then
+    if [[ $(echo $python_version'>'$min_required_version | bc -l) == 1 ]]; then
         echo "Python version: $python_version_l"
     else
         echo -e "\e[31mPython version: $python_version_l\e[0m"
         echo -e "\e[31mPlease check your Python version >= 3.6 and make sure that the appropriate Conda env is activated.\e[0m"
         exit $1
     fi
-    if [ -d "$CONDA_PREFIX/lib/$python_lib" ]; then
+    if [[ -d "$CONDA_PREFIX/lib/$python_lib" ]]; then
         echo "Found $python_lib within Conda environment."
     else
         echo -e "\e[31mPlease check your Python binary path and make sure that the appropriate Conda environment is activated.\e[0m"
@@ -22,18 +22,20 @@ function check_python {
 
 function set_grib_definition_path {
 
-    if cosmo_eccodes=$(spack find --format "{prefix}" cosmo-eccodes-definitions@2.19.0.7%gcc | head -n1); then
+    cosmo_eccodes=$(spack find --format "{prefix}" cosmo-eccodes-definitions@2.19.0.7%gcc | head -n1)
+    if ! [[ -z "$cosmo_eccodes" ]]; then
         echo 'Cosmo eccodes-definitions were successfully retrieved.'
     else
         echo -e "\e[31mCosmo eccodes-definitions could not be set properly. Please check your Spack setup.\e[0m"
-        return $1
+        exit $1
     fi
 
-    if eccodes=$(spack find --format "{prefix}" eccodes@2.19.0%gcc \~aec | head -n1); then
+    eccodes=$(spack find --format "{prefix}" eccodes@2.19.0%gcc \~aec | head -n1)
+    if ! [[ -z "$eccodes" ]]; then
         echo 'Eccodes definitions were successfully retrieved.'
     else
         echo -e "\e[31mEccodes retrieval failed. Please check your Spack setup.\e[0m"
-        return $1
+        exit $1
     fi
 
     export GRIB_DEFINITION_PATH=${cosmo_eccodes}/cosmoDefinitions/definitions/:${eccodes}/share/eccodes/definitions/

--- a/env/setup-conda-env.sh
+++ b/env/setup-conda-env.sh
@@ -31,7 +31,7 @@ elif [[ $(hostname -s) == *'daint'* ]]; then
     source /project/g110/spack/user/admin-daint/spack/share/spack/setup-env.sh
 
     cosmo_eccodes=$(spack find --format "{prefix}" cosmo-eccodes-definitions@2.19.0.7%gcc | head -n1)
-    eccodes=$(spack find --format "{prefix}" eccodes@2.19.0%gcc ~aec | head -n1)
+    eccodes=$(spack find --format "{prefix}" eccodes@2.19.0%gcc \~aec | head -n1)
     export GRIB_DEFINITION_PATH=${cosmo_eccodes}/cosmoDefinitions/definitions/:${eccodes}/share/eccodes/definitions/
     export OMPI_MCA_pml="ucx"
     export OMPI_MCA_osc="ucx"

--- a/env/setup-conda-env.sh
+++ b/env/setup-conda-env.sh
@@ -2,17 +2,28 @@
 
 if [[ $(hostname -s) == *'tsa'* ]]; then
     echo 'Setting GRIB_DEFINITION_PATH for cfgrib engine'
-    errormessage=$(module load python)
-    if [ -z "$errormessage" ]; then
-        echo 'EasyBuild loaded the python module successfully.'
+    if module load python; then
+        echo '"module load python" was successful.'
     else
-        echo 'EasyBuild was not able to load the python module.'
+        echo '"module load python" was NOT successful. Please contact your system admin.'
         return $1
     fi
     source /project/g110/spack/user/admin-tsa/spack/share/spack/setup-env.sh
 
-    cosmo_eccodes=$(spack find --format "{prefix}" cosmo-eccodes-definitions@2.19.0.7%gcc | head -n1)
-    eccodes=$(spack find --format "{prefix}" eccodes@2.19.0%gcc \~aec | head -n1)
+    if cosmo_eccodes=$(spack find --format "{prefix}" cosmo-eccodes-definitions@2.19.0.7%gcc | head -n1); then
+        echo 'Cosmo eccodes-definitions were set successfully.'
+    else
+        echo 'Cosmo eccodes-definitions could not be set properly. Please check your Spack setup.'
+        return $1
+    fi
+
+    if eccodes=$(spack find --format "{prefix}" eccodes@2.19.0%gcc \~aec | head -n1); then
+        echo 'Eccodes were successfully retrieved.'
+    else
+        echo 'Eccodes retrieval failed. Please check your Spack setup.'
+        return $1
+    fi
+
     export GRIB_DEFINITION_PATH=${cosmo_eccodes}/cosmoDefinitions/definitions/:${eccodes}/share/eccodes/definitions/
     export OMPI_MCA_pml="ucx"
     export OMPI_MCA_osc="ucx"
@@ -21,17 +32,28 @@ if [[ $(hostname -s) == *'tsa'* ]]; then
 
 elif [[ $(hostname -s) == *'daint'* ]]; then
     echo 'Setting GRIB_DEFINITION_PATH for cfgrib engine'
-    errormessage=$(module load cray-python)
-    if [ -z "$errormessage"]; then
-        echo 'EasyBuild loaded the python module successfully.'
+    if module load cray-python; then
+        echo '"module load cray-python" was successful.'
     else
-        echo 'EasyBuild was not able to load the python module.'
+        echo '"module load cray-python" was NOT successful. Please contact your system admin.'
         return $1
     fi
     source /project/g110/spack/user/admin-daint/spack/share/spack/setup-env.sh
 
-    cosmo_eccodes=$(spack find --format "{prefix}" cosmo-eccodes-definitions@2.19.0.7%gcc | head -n1)
-    eccodes=$(spack find --format "{prefix}" eccodes@2.19.0%gcc \~aec | head -n1)
+    if cosmo_eccodes=$(spack find --format "{prefix}" cosmo-eccodes-definitions@2.19.0.7%gcc | head -n1); then
+        echo 'Cosmo eccodes-definitions were set successfully.'
+    else
+        echo 'Cosmo eccodes-definitions could not be set properly. Please check your Spack setup.'
+        return $1
+    fi
+
+    if eccodes=$(spack find --format "{prefix}" eccodes@2.19.0%gcc \~aec | head -n1); then
+        echo 'Eccodes were successfully retrieved.'
+    else
+        echo 'Eccodes retrieval failed. Please check your Spack setup.'
+        return $1
+    fi
+
     export GRIB_DEFINITION_PATH=${cosmo_eccodes}/cosmoDefinitions/definitions/:${eccodes}/share/eccodes/definitions/
     export OMPI_MCA_pml="ucx"
     export OMPI_MCA_osc="ucx"
@@ -55,12 +77,25 @@ fi
 
 # ---- required for cartopy ------
 
-python_version=$(python --version | tr '[:upper:]' '[:lower:]' | sed 's/ //g' | sed 's/\.[^.]*$//')
-vpython=$(ls --color=never -d $CONDA_PREFIX/lib/$python_version)
+if python_version=$(python --version | tr '[:upper:]' '[:lower:]' | sed 's/ //g' | sed 's/\.[^.]*$//'); then
+    echo $python_version
+else
+    echo "Please check your Python version and make sure that the appropriate Conda env is activated."
+    return $1
+fi
+if vpython=$(ls --color=never -d $CONDA_PREFIX/lib/$python_version); then
+    echo $vpython
+else
+    echo "Please check your Python binary path and make sure that the appropriate Conda env is activated."
+    return $1
+fi
 if cp env/siteconfig.py ${vpython}/site-packages/cartopy; then
-    echo -e 'The setup script completed successfully! \n' \
-        'Make sure to deactivate your environment completely before reactivating it by running "conda deactivate" twice.'
+    echo 'Cartopy configuration completed successfully.'
 else
     echo -e 'Enable cartopy to modify cartopy.config by placing the env/siteconfig.py file into cartopy package source folder. \n' \
         'Please make sure that you are in the parent directory of the iconarray folder while executing this setup script.'
+    return $1
 fi
+
+echo -e 'The setup script completed successfully! \n' \
+    'Make sure to deactivate your environment completely before reactivating it by running "conda deactivate" twice.'


### PR DESCRIPTION
Hi iconarray-team,

Big fan of the project and first time contributor (but longer time user).

Here some reasoning for the stuff I changed in the setup file:
- `$HOST` is sometimes not defined in non-login shells, using `$(hostname -s)` is more robust. This can be important for VSCode users for example
- Made sure that if module loading fails, the script aborts and returns an error message
- The `~`-sign has to be escaped when working in zsh, in bash both `\~` and `~` work
- My default formatter changed `` to `$()` syntax, which I think is clearer to read and less prone to quotation mark errors
- Copying the cartopy script failed because of non-matching Python versions, the Python version retrieval is now automatic
- Added some error messages