### PR TITLE
add a scale_factor for the crop algorithm

### DIFF
--- a/iconarray/core/crop.py
+++ b/iconarray/core/crop.py
@@ -24,6 +24,16 @@ class Crop:
         - clon,clat,elon,elat,vlon,vlat coordinates
         - edge_of_cell, vertex_of_cell variables that provide the connectivity between edge and vertex locations to the cell
 
+    lon_bnds: list[float]
+        [low,high] longitude bounds of the cropped domain
+
+    lat_bnds: list[float]
+        [low,high] latitude bounds of the cropped domain
+
+    scale_factor: float
+        factor of resolution between the icon grid and an auxiliary latlon grid needed by the cropping algorithm. 
+        We recommend using the default value and decrease it only if required.
+
     Examples
     --------
     load the grid dataset:
@@ -184,7 +194,7 @@ class Crop:
     ...     institution:             Zurich
     """
 
-    def __init__(self, grid: xr.Dataset, lon_bnds: list[float], lat_bnds: list[float]):
+    def __init__(self, grid: xr.Dataset, lon_bnds: list[float], lat_bnds: list[float], scale_factor=0.3):
         grid_lon_bnds = [
             np.amin(grid.coords["clon"].data),
             np.amax(grid.coords["clon"].data),
@@ -210,6 +220,7 @@ class Crop:
         self.lon_bnds = lon_bnds
         self.lat_bnds = lat_bnds
         self.idx_subset: Dict[str, List[int]] = {}
+        self.scale_factor=scale_factor
         self.rgrid = self.crop_grid()
 
     def _reindex_neighbour_table(self, field, loc, target_grid):
@@ -229,7 +240,7 @@ class Crop:
         # list of coordinates for the indices of the neighbors
         lon_coords = self.full_grid.coords[lon_coord_name][neighbor_flat_index]
         lat_coords = self.full_grid.coords[lat_coord_name][neighbor_flat_index]
-        i2ll = Icon2latlon(target_grid)
+        i2ll = Icon2latlon(target_grid, self.scale_factor)
 
         # compute the list of cartesian coordinates of a lat/lon grid where
         # the coordinates (of the lookup table elements) fall

--- a/iconarray/core/crop.py
+++ b/iconarray/core/crop.py
@@ -31,7 +31,7 @@ class Crop:
         [low,high] latitude bounds of the cropped domain
 
     scale_factor: float
-        factor of resolution between the icon grid and an auxiliary latlon grid needed by the cropping algorithm. 
+        factor of resolution between the icon grid and an auxiliary latlon grid needed by the cropping algorithm.
         We recommend using the default value and decrease it only if required.
 
     Examples
@@ -194,7 +194,13 @@ class Crop:
     ...     institution:             Zurich
     """
 
-    def __init__(self, grid: xr.Dataset, lon_bnds: list[float], lat_bnds: list[float], scale_factor=0.3):
+    def __init__(
+        self,
+        grid: xr.Dataset,
+        lon_bnds: list[float],
+        lat_bnds: list[float],
+        scale_factor=0.3,
+    ):
         grid_lon_bnds = [
             np.amin(grid.coords["clon"].data),
             np.amax(grid.coords["clon"].data),
@@ -220,7 +226,7 @@ class Crop:
         self.lon_bnds = lon_bnds
         self.lat_bnds = lat_bnds
         self.idx_subset: Dict[str, List[int]] = {}
-        self.scale_factor=scale_factor
+        self.scale_factor = scale_factor
         self.rgrid = self.crop_grid()
 
     def _reindex_neighbour_table(self, field, loc, target_grid):

--- a/iconarray/core/latlonhash.py
+++ b/iconarray/core/latlonhash.py
@@ -1,6 +1,6 @@
 """Functionality to locate ICON grid indices associated to lat/lon grid coordinates via hashing the indices in a Cartesian grid."""
 import math
-from typing import Tuple, Sequence
+from typing import Sequence, Tuple
 
 import numpy as np
 import xarray as xr
@@ -34,7 +34,7 @@ class Icon2latlon:
     grid: xr.Dataset
         the ICON grid information, it should contain the following coordinates: clon,clat,elon,elat,vlon,vlat
     scale_factor: float
-        factor of resolution between the icon grid and an auxiliary latlon grid needed by the cropping algorithm. 
+        factor of resolution between the icon grid and an auxiliary latlon grid needed by the cropping algorithm.
 
     Example
     -------
@@ -95,7 +95,7 @@ class Icon2latlon:
             self.grid_spec[loc] = _latlon_spec(
                 self.grid.coords[lon_coords_name],
                 self.grid.coords[lat_coords_name],
-                scale_factor
+                scale_factor,
             )
 
     def latlon_indices_of_coords(
@@ -185,5 +185,5 @@ class Icon2latlon:
         data_check[ind_clon, ind_clat] = -1
         assert np.count_nonzero(data_check == -1) == len(ind_clon)
 
-        clatlon[ind_clon, ind_clat] = np.arange(len(ind_clon),dtype=np.int32) + 1
+        clatlon[ind_clon, ind_clat] = np.arange(len(ind_clon), dtype=np.int32) + 1
         return clatlon

--- a/iconarray/core/latlonhash.py
+++ b/iconarray/core/latlonhash.py
@@ -21,6 +21,7 @@ class _latlon_spec:
         self.ratio = self.Dlon / self.Dlat
         self.dlon = math.sqrt(self.cell_area)
         self.dlat = math.sqrt(self.cell_area)
+        self.scale_factor = scale_factor
 
 
 class Icon2latlon:
@@ -159,6 +160,12 @@ class Icon2latlon:
             A new DataArray with x,y dimensions and lat/lon coordinates covering
             the original ICON grid. The values contain the indices of the corresponding
             element in the ICON grid.
+
+        Raises
+        ------
+        RuntimeError
+            if algorithm to map uniquely ICON indices into a latlon grid fails
+
         """
         _check_loc(loc)
         lon_coord_name = loc[0] + "lon"
@@ -183,6 +190,12 @@ class Icon2latlon:
         # We could do this with np.unique, but since it involves a sort (NlogN) this might be faster
         data_check = clatlon.copy()
         data_check[ind_clon, ind_clat] = -1
+        if np.count_nonzero(data_check == -1) != len(ind_clon):
+            raise RuntimeError(
+                "Algorithm to map ICON grid indices into a latlon grid failed. Try to reduce the scale_factor, currently: "
+                + str(self.grid_spec[loc].scale_factor)
+            )
+
         assert np.count_nonzero(data_check == -1) == len(ind_clon)
 
         clatlon[ind_clon, ind_clat] = np.arange(len(ind_clon), dtype=np.int32) + 1


### PR DESCRIPTION
Description
==========

the crop algorithms requires a resolution scale factor between the icon grid and an auxiliary latlon grid, use to ensure that only one grid cell will be contain in each latlon cell. A default of 0.3 works mostly, but sometimes depending on the grid this scale needs to be lower. 
In this PR we allow to pass the scale factor by argument, and the algorithm will raise if fails, asking the user to decrease the scale_factor