### PR TITLE
allow input grid as dataset

### DIFF
--- a/iconarray/backend/grid.py
+++ b/iconarray/backend/grid.py
@@ -109,22 +109,23 @@ def combine_grid_information(file, grid_file):
         except ValueError:
             logging.error(f"The grid file {grid_file} was not found.")
             sys.exit()
+    elif isinstance(grid_file, xr.core.dataset.Dataset):
+        grid = grid_file
+    else:
+        raise TypeError("""Grid file could not be opened to xr.core.dataset.Dataset.""")
+
     if isinstance(file, pathlib.PurePath) or isinstance(file, str):
         ds = open_dataset(file)
-    else:
+    elif isinstance(file, xr.core.dataset.Dataset):
         ds = file
+    else:
+        raise TypeError("""data file could not be opened to xr.core.dataset.Dataset.""")
 
     try:
         ds = ds.squeeze()
     except AttributeError:
         logging.error("Model data contains more than one hypercube.")
         sys.exit()
-
-    datasetType = xr.core.dataset.Dataset
-    if type(ds) != datasetType or type(grid) != datasetType:
-        raise TypeError(
-            """Grid or data file could not be opened to xr.core.dataset.Dataset."""
-        )
 
     cell_dim = get_cell_dim_name(ds, grid)
     if "cell" not in ds.dims and cell_dim is not None:
@@ -290,13 +291,13 @@ def add_cell_data(ds, grid):
         .assign_coords(
             clat_bnds=(
                 ("cell", "vertices"),
-                np.float32(grid.coords["clat_vertices"].values),
+                np.float32(grid.clat_vertices.values),
             )
         )
         .assign_coords(
             clon_bnds=(
                 ("cell", "vertices"),
-                np.float32(grid.coords["clon_vertices"].values),
+                np.float32(grid.clon_vertices.values),
             )
         )
     )
@@ -344,10 +345,10 @@ def add_edge_data(ds, grid):
         ds.assign_coords(elon=("edge", np.float32(grid.coords["elon"].values)))
         .assign_coords(elat=("edge", np.float32(grid.coords["elat"].values)))
         .assign_coords(
-            elat_bnds=(("edge", "no"), np.float32(grid.coords["elat_vertices"].values))
+            elat_bnds=(("edge", "no"), np.float32(grid.elat_vertices.values))
         )
         .assign_coords(
-            elon_bnds=(("edge", "no"), np.float32(grid.coords["elon_vertices"].values))
+            elon_bnds=(("edge", "no"), np.float32(grid.elon_vertices.values))
         )
         .assign_coords(zonal_normal_primal_edge=grid["zonal_normal_primal_edge"])
         .assign_coords(

--- a/iconarray/tests/test_grib.py
+++ b/iconarray/tests/test_grib.py
@@ -5,6 +5,7 @@ Contains tests: test_grid_edge, test_grid_cell
 """
 
 import cfgrib
+import xarray as xr
 
 import iconarray
 
@@ -97,3 +98,15 @@ def test_grid_cell():
         )
         == 4
     ), "ds_cellvars should have coordinates 'clon', 'clat', 'clon_bnds', 'clat_bnds'"
+
+
+def test_grid_dataset_cell():
+    """Test the API of combine_grid_information that passes a dataset instead of a filename."""
+    ds_cell, _ = _open_file(f_alldata)
+    grid_ds = xr.open_dataset(f_grid, engine="netcdf4")
+
+    ds_cellvars = iconarray.combine_grid_information(ds_cell, grid_ds)
+
+    assert "cell" in list(
+        ds_cellvars.P.dims
+    ), "ds_cellvars data variables should have a dimension 'cell'"

--- a/iconarray/tests/test_netcdf.py
+++ b/iconarray/tests/test_netcdf.py
@@ -5,6 +5,7 @@ Contains tests: test_wo_celldata, test_w_celldata, test_wrong_grid
 """
 
 import pytest
+import xarray as xr
 
 import iconarray
 from iconarray.backend import grid
@@ -73,3 +74,15 @@ def test_wrong_grid():
     """Test that combine_grid_information raises an error when trying to add the data from an incorrect grid to data from a NETCDF file."""
     with pytest.raises(grid.WrongGridException):
         iconarray.combine_grid_information(f_celldata_incomatible_w_grid, f_grid)
+
+
+def test_grid_dataset_cell():
+    """Test the API of combine_grid_information that passes a dataset instead of a filename."""
+    ds_cell = xr.open_dataset(f_wo_celldata, engine="netcdf4")
+    grid_ds = xr.open_dataset(f_grid, engine="netcdf4")
+
+    ds_cell = iconarray.combine_grid_information(ds_cell, grid_ds)
+
+    assert "cell" in list(
+        ds_cell.T.dims
+    ), "ds_cell data variables should have a dimension 'cell'"


### PR DESCRIPTION
Description
==========

currently the function combine_grid_information fails if the grid_file parameter is an xr.Dataset and not a filename. 
This PR applies fixes to support the argument as an xr.Dataset