### PR TITLE
disallow concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,13 @@ def BuildBadge = addEmbeddableBadgeConfiguration(id: "build", subject: "Build")
 def TestBadge = addEmbeddableBadgeConfiguration(id: "test", subject: "Test")
 
 pipeline {
+    options {
+    # the variable $WORKSPACE is assigned dynamically at the beginning of every stage
+    # and might change depending on the number of concurrent builds active.
+    # We can only allow 1 concurrent build to have a consistent access to $WORKSPACE
+    # Otherwise we should use stash/unstash for the miniconda installation
+        disableConcurrentBuilds()
+    }
     environment {
        EMAIL_TO_1 = 'victoria.cherkas@meteoswiss.ch'
        EMAIL_TO_2 = 'victoria.cherkas@meteoswiss.ch'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,10 +3,10 @@ def TestBadge = addEmbeddableBadgeConfiguration(id: "test", subject: "Test")
 
 pipeline {
     options {
-    # the variable $WORKSPACE is assigned dynamically at the beginning of every stage
-    # and might change depending on the number of concurrent builds active.
-    # We can only allow 1 concurrent build to have a consistent access to $WORKSPACE
-    # Otherwise we should use stash/unstash for the miniconda installation
+    // the variable $WORKSPACE is assigned dynamically at the beginning of every stage
+    // and might change depending on the number of concurrent builds active.
+    // We can only allow 1 concurrent build to have a consistent access to $WORKSPACE
+    // Otherwise we should use stash/unstash for the miniconda installation
         disableConcurrentBuilds()
     }
     environment {


### PR DESCRIPTION
Description
-------------------
the variable $WORKSPACE is assigned dynamically at the beginning of every stage
and might change depending on the number of concurrent builds active.
We can only allow 1 concurrent build to have a consistent access to $WORKSPACE
Otherwise we should use stash/unstash for the miniconda installation
