### PR TITLE
optimize crop

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.9.7
+  python: python3.9.14
 repos:
 
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.9.14
+  python: python3.9.7
 repos:
 
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/iconarray/core/crop.py
+++ b/iconarray/core/crop.py
@@ -326,7 +326,7 @@ class Crop:
             self.full_grid["vertex_of_cell"][:, self.idx_sublist["cell"]].data.flatten()
             - 1
         )
-        for loc in ('cell','edge','vertex'):
+        for loc in ("cell", "edge", "vertex"):
             self.idx_subset[loc] = set(self.idx_sublist[loc])
 
         return self._reindex_neighbour_tables(self.crop_fields())


### PR DESCRIPTION
Description
==========

the cropping algorithm was slow, particularly noticeable for high resolutions like, R19B08.
A performance bottleneck was here: 
https://github.com/C2SM/iconarray/blob/77b3d621067bc0bd27c9b4a682fb03bfcee73461/iconarray/core/crop.py#L243

where it filters out indices that are not in the list of selected indices (initially, based on coords within the cropping frame).
But for each element the condition was checking whether the index is in a list, therefore O(N^2). 
In this PR we create a set out of the list, 
https://github.com/C2SM/iconarray/pull/48/files#diff-834d542c9c7b7e33f7e73e6ea15bbf8ea87e735868228c9816bd13db9bdeb33eR330
to be used in the check so that for each element the complexity is constant O(0), and therefore the entire selection is O(N)