### PR TITLE
Always run documentation github action on PRs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,7 @@ name: docs
 on:
   push:
     branches:
-    - main
+    - *
 
 jobs:
   build:
@@ -25,6 +25,7 @@ jobs:
     # Publish built docs to gh-pages branch.
     # ===============================
     - name: Commit documentation changes
+    - if: github.ref == 'refs/heads/main'
       run: |
         pwd
         ls doc

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,4 +1,4 @@
-name: docs
+name: Documentation
 
 on:
   push:
@@ -7,10 +7,9 @@ on:
   pull_request:
     branches:
     - main
-    
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -25,10 +24,14 @@ jobs:
       with:
         name: DocumentationHTML
         path: doc/_build/
+
+  publish:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
     # Publish built docs to gh-pages branch.
     # ===============================
     - name: Commit documentation changes
-    - if: github.ref == 'refs/heads/main'
       run: |
         pwd
         ls doc

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,9 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/checkout@v1
+    - uses: actions/download-artifact@v3
       with:
         name: DocumentationHTML
+        path: doc/_build/
     # Publish built docs to gh-pages branch.
     # ===============================
     - name: Commit documentation changes

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,6 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: DocumentationHTML
     # Publish built docs to gh-pages branch.
     # ===============================
     - name: Commit documentation changes

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,8 +3,11 @@ name: docs
 on:
   push:
     branches:
-    - *
-
+    - main
+  pull_request:
+    branches:
+    - main
+    
 jobs:
   build:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,7 +68,7 @@ autodoc_mock_imports = [
     "pytest",
     "urllib",
     "ftplib",
-    "sklearn"
+    "sklearn",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,6 +68,7 @@ autodoc_mock_imports = [
     "pytest",
     "urllib",
     "ftplib",
+    "sklearn"
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
A recent PR was merged to main causing the Documentation github action to fail. This would have been avoided had we run the documentation github action on all PRs (although without actually publishing the docs from the branch). This PR aims to fix this. 